### PR TITLE
Upgrading to Nan 2.2.0 for compatibility with newer versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "objhash",
   "main": "objhash",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Retrieve a node.js object's V8 identity hash",
   "repository": {
     "type": "git",
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^1.4.1"
+    "nan": "^2.2.0"
   }
 }

--- a/src/objhash.cc
+++ b/src/objhash.cc
@@ -1,23 +1,20 @@
 #include <nan.h>
 
-using namespace v8;
-
-NAN_METHOD(Ident) {
-  NanScope();
-  if (args.Length() < 1) {
-    NanReturnUndefined();
-  } else if (args[0]->IsObject()) {
-    int hash = args[0]->ToObject()->GetIdentityHash();
-    NanReturnValue(NanNew<Number>(hash));
+void Method(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  if (info.Length() < 1) {
+    info.GetReturnValue().Set(Nan::Undefined());
+  } else if (info[0]->IsObject()) {
+    int hash = info[0]->ToObject()->GetIdentityHash();
+    info.GetReturnValue().Set(Nan::New(hash));
   } else {
-    NanReturnValue(args[0]);
+    info.GetReturnValue().Set(info[0]);
   }
 }
 
-void Init(Handle<Object> exports) {
+void Init(v8::Handle<v8::Object> exports) {
   exports->Set(
-    NanNew("ident"), 
-    NanNew<FunctionTemplate>(Ident)->GetFunction()
+    Nan::New("ident").ToLocalChecked(),
+    Nan::New<v8::FunctionTemplate>(Method)->GetFunction()
   );
 }
 


### PR DESCRIPTION
Tested with Node versions 0.8.28, 0.10.32, 0.12.12, and 4.3.0

Bumped Rev to 1.0.6 since this is just a bug fix and is backwards compatible.

All Praise and glory goes to @Cauldrath

@OverFlow636 
